### PR TITLE
build: support Windows and CGO_ENABLED=0 targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,22 +10,29 @@ A complete Go implementation of [Impacket](https://github.com/fortra/impacket) -
 git clone https://github.com/mandiant/gopacket
 cd gopacket
 
-# Build and install all tools as gopacket-<toolname> on your PATH
+# Default: Linux/macOS build + install to /usr/local/bin
 ./install.sh
 
-# Or just build without installing
+# Run with no flags and it prompts you through the choices interactively.
+# Or pick a target directly:
+./install.sh --target portable   # static Linux binaries in ./dist/portable/
+./install.sh --target windows    # Windows .exe cross-compiles in ./dist/windows/
+./install.sh --target all        # build every target in one run
+
+# Build without installing (native only)
 ./install.sh --build-only
 
 # Or build with make
 make build
 ```
 
-Requires Go 1.24.13+, GCC, and libpcap development headers
-(install with `apt install build-essential libpcap-dev` on Debian/Ubuntu/Kali,
-or `yum install gcc libpcap-devel` on RHEL/CentOS, or `brew install libpcap` on macOS).
-
-The libpcap headers are only needed by the `sniff` and `split` tools - if
-libpcap is missing, `install.sh` will skip those two and build the rest.
+The default (`--target native`) build needs Go 1.24.13+, GCC, and libpcap
+development headers (`apt install build-essential libpcap-dev` on
+Debian/Ubuntu/Kali, `yum install gcc libpcap-devel` on RHEL/CentOS, or
+`brew install libpcap` on macOS). The `portable` and `windows` targets only
+need the Go toolchain; `sniff` and `split` become stubs in those builds
+because they require libpcap. See [Platform Support](#platform-support) for
+the full matrix.
 
 ### Platform Support
 

--- a/README.md
+++ b/README.md
@@ -29,12 +29,19 @@ libpcap is missing, `install.sh` will skip those two and build the rest.
 
 ### Platform Support
 
-Linux and macOS only. Native Windows builds (MSYS2/MINGW64, plain `go build`
-on Windows) are **not supported** - `pkg/transport` uses libc's `connect()`
-via cgo so that `LD_PRELOAD`-based proxies like proxychains can hook it,
-which has no Windows equivalent. On Windows, use
-[WSL](https://learn.microsoft.com/windows/wsl/install) and build from inside
-the Linux environment.
+gopacket builds on Linux, macOS, and Windows. The set of working tools and
+available proxying paths depends on the build flags:
+
+| Build                                  | Tools available                        | Proxying                                            |
+|----------------------------------------|----------------------------------------|-----------------------------------------------------|
+| Linux / macOS with cgo (default)       | All 63                                 | proxychains (LD_PRELOAD) and/or `-proxy` SOCKS5     |
+| Linux with `CGO_ENABLED=0`             | 61 (`sniff`, `split` become stubs)     | `-proxy` only (proxychains needs the libc hook)     |
+| Windows (`GOOS=windows CGO_ENABLED=0`) | 60 (`sniff`, `split`, `sniffer` stubs) | `-proxy` only (no `LD_PRELOAD` on Windows)          |
+
+`sniff` and `split` depend on libpcap via cgo; `sniffer` depends on Unix raw
+sockets. When a tool can't be built for the target, gopacket substitutes a
+stub that prints a clear message and exits 1, so `go build ./...` always
+succeeds and the install layout is consistent across platforms.
 
 To uninstall:
 ```bash
@@ -63,7 +70,7 @@ gopacket-secretsdump -proxy socks5h://127.0.0.1:1080 'domain/user:password@targe
 ALL_PROXY=socks5h://127.0.0.1:1080 gopacket-smbclient 'domain/user:password@target'
 ```
 
-UDP-dependent features are **disabled** under `-proxy` rather than silently leaking packets (SOCKS5 UDP ASSOCIATE is rarely supported by proxies, and bypassing the proxy for UDP would reveal the attacker's real source IP). Affected features and their workarounds are documented in [KNOWN_ISSUES.md #9](KNOWN_ISSUES.md).
+UDP-dependent features are **disabled** under `-proxy` rather than silently leaking packets (SOCKS5 UDP ASSOCIATE is rarely supported by proxies, and bypassing the proxy for UDP would reveal the operator's real source IP). Affected features and their workarounds are documented in [KNOWN_ISSUES.md](KNOWN_ISSUES.md).
 
 **Chaining:** `-proxy` is compatible with proxychains. The TCP connection to the SOCKS5 proxy itself still goes through libc `connect()`, so `proxychains → gopacket → -proxy → target` works for nested routing scenarios.
 

--- a/install.sh
+++ b/install.sh
@@ -30,23 +30,53 @@ YELLOW='\033[1;33m'
 NC='\033[0m'
 
 usage() {
-    echo "Usage: $0 [OPTIONS]"
-    echo ""
-    echo "Options:"
-    echo "  --prefix DIR    Install to DIR (default: /usr/local/bin)"
-    echo "  --build-only    Build but don't install"
-    echo "  --uninstall     Remove installed gopacket tools"
-    echo "  -h, --help      Show this help"
-    echo ""
-    echo "Environment:"
-    echo "  INSTALL_DIR     Same as --prefix (default: /usr/local/bin)"
+    cat <<'EOF'
+Usage: ./install.sh [OPTIONS]
+
+Build and install gopacket tools. Run with no flags to get an interactive
+prompt explaining the build targets.
+
+Options:
+  --target NAME   Build target. One of:
+                    native    (default) Linux/macOS cgo, installs to
+                              /usr/local/bin. All 63 tools; proxychains
+                              and -proxy both work. Needs GCC + libpcap-dev.
+                    portable  Static host-OS binaries, no system libs.
+                              sniff/split stubbed; use -proxy (proxychains
+                              won't hook). Output: ./dist/portable/
+                    windows   Windows amd64 cross-compile. sniff/split/
+                              sniffer stubbed; -proxy only (no LD_PRELOAD
+                              on Windows). Output: ./dist/windows/
+                    all       Build every target.
+
+  --prefix DIR    For the native target, install to DIR instead of
+                  /usr/local/bin. Has no effect on cross-compile targets.
+  --build-only    Build but don't install (native target only).
+  --uninstall     Remove previously installed gopacket-* binaries from
+                  $INSTALL_DIR. Affects native installs only.
+  -h, --help      Show this help.
+
+Environment:
+  INSTALL_DIR     Same as --prefix.
+
+Examples:
+  ./install.sh                          Interactive, prompts for target
+  ./install.sh --target native          Today's default (build + install)
+  ./install.sh --target windows         Cross-compile Windows .exe files
+  ./install.sh --target all             Build every target in one run
+EOF
 }
 
+target=""
 build_only=false
 uninstall=false
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
+        --target)
+            target="$2"
+            shift 2
+            ;;
         --prefix)
             INSTALL_DIR="$2"
             shift 2
@@ -90,35 +120,6 @@ if $uninstall; then
     exit 0
 fi
 
-# Check dependencies
-if ! command -v go &>/dev/null; then
-    echo -e "${RED}Error: go is not installed or not in PATH${NC}"
-    echo "Install Go from https://go.dev/dl/"
-    exit 1
-fi
-
-if ! command -v gcc &>/dev/null; then
-    echo -e "${RED}Error: gcc is not installed${NC}"
-    echo "Install with: apt install build-essential (Debian/Ubuntu) or yum install gcc (RHEL/CentOS)"
-    exit 1
-fi
-
-# Check for libpcap headers (needed only by sniff and split tools)
-HAS_LIBPCAP=true
-if ! [ -f /usr/include/pcap.h ] \
-   && ! [ -f /usr/include/pcap/pcap.h ] \
-   && ! [ -f /usr/local/include/pcap.h ] \
-   && ! [ -f /opt/homebrew/include/pcap.h ] \
-   && ! pkg-config --exists libpcap 2>/dev/null; then
-    HAS_LIBPCAP=false
-    echo -e "${YELLOW}Warning: libpcap development headers not found${NC}"
-    echo "  The sniff and split tools will be skipped."
-    echo "  Install with: apt install libpcap-dev (Debian/Ubuntu/Kali)"
-    echo "             or yum install libpcap-devel (RHEL/CentOS)"
-    echo "             or brew install libpcap (macOS)"
-    echo ""
-fi
-
 # Determine script directory (where go.mod lives)
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR"
@@ -128,86 +129,240 @@ if [ ! -f go.mod ]; then
     exit 1
 fi
 
-# Discover tools
-tools=($(ls tools/))
-total=${#tools[@]}
+# Interactive prompt if no --target given and stdin is a terminal.
+if [ -z "$target" ]; then
+    if [ -t 0 ]; then
+        cat <<'EOF'
+gopacket installer
 
-echo "gopacket installer"
-echo "  Tools:   ${total}"
-echo "  Build:   ${BUILD_DIR}/"
-if ! $build_only; then
-    echo "  Install: ${INSTALL_DIR}/"
-fi
-echo ""
+Pick a build target. If unsure, pick (1).
 
-# Build
-echo "Building ${total} tools..."
-mkdir -p "${BUILD_DIR}"
+  (1) native
+      Linux/macOS cgo, installs to /usr/local/bin. All 63 tools; supports
+      both proxychains (LD_PRELOAD) and the -proxy SOCKS5 flag.
+      Needs GCC + libpcap-dev installed.
 
-failed=0
-skipped=0
-for tool in "${tools[@]}"; do
-    if ! $HAS_LIBPCAP && { [ "$tool" = "sniff" ] || [ "$tool" = "split" ]; }; then
-        echo -e "  ${tool}... ${YELLOW}skipped (libpcap-dev not installed)${NC}"
-        skipped=$((skipped + 1))
-        continue
-    fi
-    echo -n "  ${tool}... "
-    if err=$(CGO_ENABLED=1 go build -o "${BUILD_DIR}/${tool}" \
-        -ldflags '-linkmode external -extldflags "-static-libgcc"' \
-        "./tools/${tool}" 2>&1); then
-        echo -e "${GREEN}ok${NC}"
+  (2) portable
+      Static single-file binaries for your host OS, no system libs needed.
+      sniff/split are stubs (they need libpcap). proxychains can't hook a
+      cgo-off Go binary, so use -proxy instead. Output: ./dist/portable/
+
+  (3) windows
+      Windows amd64 .exe cross-compile. sniff/split/sniffer are stubs.
+      No LD_PRELOAD on Windows, so -proxy is the only proxy path.
+      Output: ./dist/windows/
+
+  (4) all
+      Build every target.
+
+EOF
+        read -r -p "Choice [1-4, default 1]: " choice
+        choice="${choice:-1}"
+        case "$choice" in
+            1) target="native" ;;
+            2) target="portable" ;;
+            3) target="windows" ;;
+            4) target="all" ;;
+            *) echo -e "${RED}Invalid choice: $choice${NC}"; exit 1 ;;
+        esac
+        echo ""
     else
-        echo -e "${RED}failed${NC}"
-        echo "$err" | sed 's/^/      /'
-        failed=$((failed + 1))
+        # Non-TTY (piped, CI). Default to native without prompting.
+        target="native"
     fi
-done
+fi
 
-if [ $failed -gt 0 ]; then
-    echo -e "\n${RED}${failed} tool(s) failed to build${NC}"
+# Validate target
+case "$target" in
+    native|portable|windows|all) ;;
+    *)
+        echo -e "${RED}Error: unknown target '$target'${NC}"
+        echo "Valid targets: native, portable, windows, all"
+        exit 1
+        ;;
+esac
+
+# Check the Go toolchain is present (all targets need this).
+if ! command -v go &>/dev/null; then
+    echo -e "${RED}Error: go is not installed or not in PATH${NC}"
+    echo "Install Go from https://go.dev/dl/"
     exit 1
 fi
 
-built=$((total - skipped))
-echo -e "\n${GREEN}Built ${built}/${total} tools successfully${NC}"
-if [ $skipped -gt 0 ]; then
-    echo -e "${YELLOW}Skipped ${skipped} tool(s) — install libpcap-dev to enable them${NC}"
-fi
+# build_target runs the build for one of: native, portable, windows.
+# Sets the right GOOS/CGO_ENABLED, picks an output directory, and iterates
+# over every tool in tools/. Stubs defined in the tools handle the cases
+# where a tool cannot be built for the target.
+build_target() {
+    local t="$1"
+    local goos goarch cgo outdir exe_suffix pcap_check label
+    case "$t" in
+        native)
+            goos=""
+            goarch=""
+            cgo=1
+            outdir="$BUILD_DIR"
+            exe_suffix=""
+            pcap_check=true
+            label="native (host OS, cgo on)"
+            ;;
+        portable)
+            goos=""   # inherit host OS
+            goarch="" # inherit host arch
+            cgo=0
+            outdir="./dist/portable"
+            exe_suffix=""
+            pcap_check=false
+            label="portable (host OS, cgo off, sniff/split stubbed)"
+            ;;
+        windows)
+            goos="windows"
+            goarch="amd64"
+            cgo=0
+            outdir="./dist/windows"
+            exe_suffix=".exe"
+            pcap_check=false
+            label="windows (GOOS=windows amd64, sniff/split/sniffer stubbed)"
+            ;;
+    esac
 
-if $build_only; then
-    echo "Binaries are in ${BUILD_DIR}/"
+    echo ""
+    echo -e "${GREEN}=== Building ${label} ===${NC}"
+
+    # Native target needs GCC for cgo and benefits from libpcap to get real
+    # sniff/split. Cross-compile targets use stubs and need neither.
+    if [ "$t" = "native" ]; then
+        if ! command -v gcc &>/dev/null; then
+            echo -e "${RED}Error: gcc is required for the native target (cgo)${NC}"
+            echo "Install with: apt install build-essential (Debian/Ubuntu) or yum install gcc (RHEL/CentOS)"
+            return 1
+        fi
+    fi
+
+    local has_libpcap=true
+    if $pcap_check; then
+        if ! [ -f /usr/include/pcap.h ] \
+           && ! [ -f /usr/include/pcap/pcap.h ] \
+           && ! [ -f /usr/local/include/pcap.h ] \
+           && ! [ -f /opt/homebrew/include/pcap.h ] \
+           && ! pkg-config --exists libpcap 2>/dev/null; then
+            has_libpcap=false
+            echo -e "${YELLOW}Warning: libpcap development headers not found${NC}"
+            echo "  sniff and split will be skipped in this target."
+            echo "  Install with: apt install libpcap-dev (Debian/Ubuntu/Kali)"
+            echo "             or yum install libpcap-devel (RHEL/CentOS)"
+            echo "             or brew install libpcap (macOS)"
+            echo ""
+        fi
+    fi
+
+    local tools
+    tools=($(ls tools/))
+    local total=${#tools[@]}
+
+    mkdir -p "$outdir"
+
+    local failed=0 skipped=0
+    for tool in "${tools[@]}"; do
+        # On native without libpcap, skip sniff/split entirely (same as the
+        # old behavior). On other targets, stubs handle the skip automatically.
+        if [ "$t" = "native" ] && ! $has_libpcap && { [ "$tool" = "sniff" ] || [ "$tool" = "split" ]; }; then
+            echo -e "  ${tool}... ${YELLOW}skipped (libpcap-dev not installed)${NC}"
+            skipped=$((skipped + 1))
+            continue
+        fi
+        echo -n "  ${tool}... "
+        local out_path="${outdir}/${tool}${exe_suffix}"
+        local build_cmd=(go build -o "$out_path")
+        if [ "$t" = "native" ]; then
+            # Static-link libgcc so binaries run on minimally-versioned hosts.
+            build_cmd+=(-ldflags '-linkmode external -extldflags "-static-libgcc"')
+        fi
+        build_cmd+=("./tools/${tool}")
+        if err=$(GOOS="$goos" GOARCH="$goarch" CGO_ENABLED="$cgo" "${build_cmd[@]}" 2>&1); then
+            echo -e "${GREEN}ok${NC}"
+        else
+            echo -e "${RED}failed${NC}"
+            echo "$err" | sed 's/^/      /'
+            failed=$((failed + 1))
+        fi
+    done
+
+    if [ $failed -gt 0 ]; then
+        echo -e "\n${RED}${failed} tool(s) failed to build for ${t}${NC}"
+        return 1
+    fi
+
+    local built=$((total - skipped))
+    echo -e "\n${GREEN}Built ${built}/${total} tools for ${t} in ${outdir}/${NC}"
+    if [ $skipped -gt 0 ]; then
+        echo -e "${YELLOW}Skipped ${skipped} tool(s), install libpcap-dev to enable them${NC}"
+    fi
+    return 0
+}
+
+# Install is only meaningful for the native target. Cross-compile outputs
+# live in ./dist/ for the user to copy to the right host.
+install_native() {
+    echo ""
+    echo "Installing to ${INSTALL_DIR}/ as gopacket-<toolname>..."
+
+    local SUDO=""
+    if [ ! -w "${INSTALL_DIR}" ]; then
+        echo -e "${YELLOW}Note: ${INSTALL_DIR} requires elevated permissions${NC}"
+        echo "Re-running install step with sudo..."
+        SUDO="sudo"
+    fi
+
+    local tools
+    tools=($(ls tools/))
+    local installed=0
+    for tool in "${tools[@]}"; do
+        if [ ! -f "${BUILD_DIR}/${tool}" ]; then
+            continue
+        fi
+        local normalized
+        normalized=$(echo "$tool" | tr '[:upper:]' '[:lower:]' | tr '_' '-')
+        local dest="${INSTALL_DIR}/gopacket-${normalized}"
+        $SUDO cp "${BUILD_DIR}/${tool}" "$dest"
+        $SUDO chmod +x "$dest"
+        installed=$((installed + 1))
+    done
+
+    echo -e "${GREEN}Installed ${installed} tools to ${INSTALL_DIR}/${NC}"
+    echo ""
+    echo "Tools are available as:"
+    echo "  gopacket-secretsdump, gopacket-smbclient, gopacket-psexec, etc."
+    echo ""
+    echo "Run 'gopacket-<tool> -h' for help on any tool."
+    echo "To uninstall: $0 --uninstall"
+}
+
+# Run the requested target(s).
+if [ "$target" = "all" ]; then
+    build_target native || exit 1
+    build_target portable || exit 1
+    build_target windows || exit 1
+    if ! $build_only; then
+        install_native
+    fi
+    echo ""
+    echo -e "${GREEN}All targets built.${NC}"
+    echo "  native   -> ${BUILD_DIR}/"
+    echo "  portable -> ./dist/portable/"
+    echo "  windows  -> ./dist/windows/"
     exit 0
 fi
 
-# Install
-echo ""
-echo "Installing to ${INSTALL_DIR}/ as gopacket-<toolname>..."
+build_target "$target" || exit 1
 
-# Check write permissions
-if [ ! -w "${INSTALL_DIR}" ]; then
-    echo -e "${YELLOW}Note: ${INSTALL_DIR} requires elevated permissions${NC}"
-    echo "Re-running install step with sudo..."
-    SUDO="sudo"
+if [ "$target" = "native" ] && ! $build_only; then
+    install_native
+elif [ "$target" = "native" ] && $build_only; then
+    echo ""
+    echo "Binaries are in ${BUILD_DIR}/"
 else
-    SUDO=""
+    echo ""
+    echo "Binaries are in $([ "$target" = "portable" ] && echo ./dist/portable/ || echo ./dist/windows/)"
+    echo "Copy them to the target host and run."
 fi
-
-for tool in "${tools[@]}"; do
-    if [ ! -f "${BUILD_DIR}/${tool}" ]; then
-        continue
-    fi
-    # Normalize tool name: lowercase, replace special chars with hyphens
-    normalized=$(echo "$tool" | tr '[:upper:]' '[:lower:]' | tr '_' '-')
-    dest="${INSTALL_DIR}/gopacket-${normalized}"
-    $SUDO cp "${BUILD_DIR}/${tool}" "$dest"
-    $SUDO chmod +x "$dest"
-done
-
-echo -e "${GREEN}Installed ${built} tools to ${INSTALL_DIR}/${NC}"
-echo ""
-echo "Tools are available as:"
-echo "  gopacket-secretsdump, gopacket-smbclient, gopacket-psexec, etc."
-echo ""
-echo "Run 'gopacket-<tool> -h' for help on any tool."
-echo "To uninstall: $0 --uninstall"

--- a/tools/sniff/main.go
+++ b/tools/sniff/main.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !windows && cgo
+
 package main
 
 import (

--- a/tools/sniff/main_stub.go
+++ b/tools/sniff/main_stub.go
@@ -1,0 +1,27 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows || !cgo
+
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Fprintln(os.Stderr, "sniff: not built. This tool needs libpcap via cgo; rebuild with CGO_ENABLED=1 on Linux or macOS.")
+	os.Exit(1)
+}

--- a/tools/sniffer/main.go
+++ b/tools/sniffer/main.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !windows
+
 package main
 
 import (

--- a/tools/sniffer/main_windows.go
+++ b/tools/sniffer/main_windows.go
@@ -1,0 +1,27 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Fprintln(os.Stderr, "sniffer: not supported on Windows. This tool depends on Unix raw sockets; rebuild on Linux or macOS.")
+	os.Exit(1)
+}

--- a/tools/split/main.go
+++ b/tools/split/main.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !windows && cgo
+
 package main
 
 import (

--- a/tools/split/main_stub.go
+++ b/tools/split/main_stub.go
@@ -1,0 +1,27 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build windows || !cgo
+
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Fprintln(os.Stderr, "split: not built. This tool needs libpcap via cgo; rebuild with CGO_ENABLED=1 on Linux or macOS.")
+	os.Exit(1)
+}


### PR DESCRIPTION
## Summary

Finishes what #5 started. Makes `go build ./...` succeed on Windows (`GOOS=windows CGO_ENABLED=0`) and on Linux with `CGO_ENABLED=0`, without forcing users through WSL. Pairs with the `-proxy` flag from #10 so Windows and cgo-off users have a proxy path at all.

Builds on the `direct_portable.go` scaffolding already landed in #10, which provides the pure-Go dialer non-cgo / Windows builds fall back to. This PR just tags the three tools that can't follow that path, gives them stubs, teaches the installer about the new targets, and updates the README accordingly.

## Changes

- **Build tags on the three affected tools:**
  - `tools/sniff/main.go`, `tools/split/main.go`: tagged `!windows && cgo` (they import `github.com/google/gopacket/pcap`, which needs libpcap via cgo). New `main_stub.go` tagged `windows || !cgo`.
  - `tools/sniffer/main.go`: tagged `!windows` (Unix raw sockets via `syscall.Socket` + `IP_HDRINCL`, no cgo dependency). New `main_windows.go` tagged `windows`.
  - Each stub prints a one-line "not supported on this build" message and exits 1, so `go build ./...` always produces a binary and the install layout stays consistent across platforms.

- **`install.sh` gets a `--target` flag:**
  - `--target native` (default): today's flow, Linux/macOS cgo, install to `/usr/local/bin`.
  - `--target portable`: `CGO_ENABLED=0` for the host OS, output in `./dist/portable/`.
  - `--target windows`: `GOOS=windows CGO_ENABLED=0`, `.exe` output in `./dist/windows/`.
  - `--target all`: build every target in one run.
  - When run with no flags and a TTY on stdin, the installer prints an interactive menu explaining each target briefly (tool set, proxy path, output location). Non-TTY invocations (CI, pipes) default silently to native so existing automation keeps working.

- **README updates:**
  - Installation section gains example `--target` invocations.
  - New "Platform Support" table shows the three build configurations, which tools are available in each, and which proxy path works.
  - Dropped a stale `#9` section-number reference in the Proxy Support section.

## Not changed

- `install.sh`'s libpcap check stays for the native target. Cross-compile targets skip it (the stubs handle the absence). The existing sniff/split skip-when-libpcap-missing behavior is preserved for native builds.
- `pkg/third_party/smb2` handles its own platform concerns; no tags needed from us.
- The cross-compile binaries use raw tool names (`ping.exe`, `net.exe`, etc). These collide with Windows built-ins when run from the same directory in cmd.exe. The native install already prefixes with `gopacket-`; doing the same for cross-compile outputs is queued as a follow-up.

## Test plan

- [x] `go build ./...` clean (default, cgo=1 Linux)
- [x] `CGO_ENABLED=0 go build ./...` clean
- [x] `GOOS=windows CGO_ENABLED=0 go build ./...` clean
- [x] `go vet ./...` clean across all three configurations
- [x] `go test ./pkg/transport/` passes, 13/13
- [x] `CGO_ENABLED=0 go test ./pkg/transport/` passes, 13/13, exercising the portable `directDial` path end-to-end
- [x] Live Windows smoke test against a small single-DC AD lab. Cross-compiled `.exe` binaries confirmed working: `DumpNTLMInfo` (SMB2 negotiate + NTLM info), `lookupsid` (SAMR over SMB named pipe), `samrdump` (SAMR user/group enum), `rpcdump` (RPC epmapper, 435 endpoints listed). Four different protocol stacks exercised via the pure-Go `net.Dialer` path on Windows.