### PR TITLE
install.sh: prefix cross-compile outputs with gopacket-

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -272,7 +272,20 @@ build_target() {
             continue
         fi
         echo -n "  ${tool}... "
-        local out_path="${outdir}/${tool}${exe_suffix}"
+        # Cross-compile outputs get the same gopacket- prefix as the native
+        # install, so users copying a .exe to a Windows host don't end up with
+        # ping.exe / net.exe / reg.exe shadowing built-ins of the same name.
+        # Native stays as the raw name here; install_native prefixes when it
+        # copies to INSTALL_DIR.
+        local out_name
+        if [ "$t" = "native" ]; then
+            out_name="$tool"
+        else
+            local normalized
+            normalized=$(echo "$tool" | tr '[:upper:]' '[:lower:]' | tr '_' '-')
+            out_name="gopacket-${normalized}"
+        fi
+        local out_path="${outdir}/${out_name}${exe_suffix}"
         local build_cmd=(go build -o "$out_path")
         if [ "$t" = "native" ]; then
             # Static-link libgcc so binaries run on minimally-versioned hosts.


### PR DESCRIPTION
## Summary

Follow-up to #12. The native install already renamed each tool to `gopacket-<toolname>` before copying to `/usr/local/bin`, but the portable and windows cross-compile targets dropped raw binaries like `ping.exe`, `net.exe`, `reg.exe`, `attrib.exe`, `services.exe` into `./dist/`.

Surfaced during the Windows lab smoke test: when the test `.bat` ran `ping -n 1 <target>` from the directory where the binaries lived, `cmd.exe`'s PATH resolution picked up the local `ping.exe` (gopacket's ping tool) before the Windows built-in, producing a confusing `[-] Invalid source IPv4 address: -n` error.

## Changes

- `install.sh` applies the same normalization (lowercase, underscores to hyphens) and `gopacket-` prefix the native install already uses, but at build time for cross-compile targets.
- Native behavior is unchanged: `./bin/` still gets raw names so `install_native` can prefix them on copy to `INSTALL_DIR`.

Before:
```
./dist/windows/ping.exe
./dist/windows/net.exe
./dist/windows/reg.exe
```

After:
```
./dist/windows/gopacket-ping.exe
./dist/windows/gopacket-net.exe
./dist/windows/gopacket-reg.exe
```

## Test plan

- [x] `./install.sh --target windows --build-only` produces 63 `gopacket-<tool>.exe` files in `./dist/windows/`
- [x] `./install.sh --target portable --build-only` produces 63 `gopacket-<tool>` files in `./dist/portable/`
- [x] `./install.sh --target native --build-only` still produces raw names in `./bin/` (install_native renames on copy, unchanged behavior)
- [x] Collision-prone tools (`ping`, `net`, `reg`, `attrib`, `services`, `getarch`, `netview`, `ping6`, `registry-read`) all come out as `gopacket-<name>`