### PR TITLE
version: centralize banner through flags.Banner()

### DIFF
--- a/tools/CheckLDAPStatus/main.go
+++ b/tools/CheckLDAPStatus/main.go
@@ -39,7 +39,7 @@ var (
 
 func main() {
 	flag.Usage = func() {
-		fmt.Fprintln(os.Stderr, "gopacket v0.1.1-beta - Copyright 2026 Google LLC")
+		fmt.Fprintln(os.Stderr, flags.Banner())
 		fmt.Fprintln(os.Stderr)
 		fmt.Fprintln(os.Stderr, "LDAP signing and channel binding enumeration utility.")
 		fmt.Fprintln(os.Stderr)

--- a/tools/DumpNTLMInfo/main.go
+++ b/tools/DumpNTLMInfo/main.go
@@ -76,7 +76,7 @@ const EPOCH_DIFF = 116444736000000000
 
 func main() {
 	flag.Usage = func() {
-		fmt.Fprintln(os.Stderr, "gopacket v0.1.1-beta - Copyright 2026 Google LLC")
+		fmt.Fprintln(os.Stderr, flags.Banner())
 		fmt.Fprintln(os.Stderr)
 		fmt.Fprintln(os.Stderr, "Do NTLM authentication and parse information.")
 		fmt.Fprintln(os.Stderr)

--- a/tools/describeTicket/main.go
+++ b/tools/describeTicket/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/jcmturner/gokrb5/v8/messages"
 	"github.com/jcmturner/gokrb5/v8/types"
 
+	gopflags "github.com/mandiant/gopacket/pkg/flags"
 	"github.com/mandiant/gopacket/pkg/kerberos"
 )
 
@@ -966,7 +967,7 @@ func loadCCacheSafe(path string) (ccache *credentials.CCache, err error) {
 }
 
 func printUsage() {
-	fmt.Println("gopacket v0.1.1-beta - Copyright 2026 Google LLC")
+	fmt.Println(gopflags.Banner())
 	fmt.Println()
 	fmt.Println("Parses a ccache ticket file and displays credential information.")
 	fmt.Println("With a decryption key, decrypts the ticket and shows the full PAC.")

--- a/tools/getArch/main.go
+++ b/tools/getArch/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mandiant/gopacket/pkg/dcerpc"
 	"github.com/mandiant/gopacket/pkg/dcerpc/epmapper"
 	"github.com/mandiant/gopacket/pkg/dcerpc/header"
+	"github.com/mandiant/gopacket/pkg/flags"
 	"github.com/mandiant/gopacket/pkg/transport"
 )
 
@@ -123,7 +124,7 @@ func checkArch(machine string, timeoutSec int) {
 }
 
 func printUsage() {
-	fmt.Println("gopacket v0.1.1-beta - Copyright 2026 Google LLC")
+	fmt.Println(flags.Banner())
 	fmt.Println()
 	fmt.Println("Gets the target system's OS architecture version")
 	fmt.Println()

--- a/tools/karmaSMB/main.go
+++ b/tools/karmaSMB/main.go
@@ -275,7 +275,7 @@ var NDR_UUID = []byte{
 
 func main() {
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "gopacket v0.1.1-beta - Copyright 2026 Google LLC\n\n")
+		fmt.Fprintf(os.Stderr, "%s\n\n", flags.Banner())
 		fmt.Fprintf(os.Stderr, "For every file request received, this module will return the pathname\n")
 		fmt.Fprintf(os.Stderr, "contents based on extension matching.\n\n")
 		fmt.Fprintf(os.Stderr, "Usage: karmaSMB [options] pathname\n\n")

--- a/tools/keylistattack/main.go
+++ b/tools/keylistattack/main.go
@@ -73,8 +73,8 @@ func main() {
 }
 
 func usage() {
-	fmt.Fprintf(os.Stderr, `gopacket v0.1.1-beta - Copyright 2026 Google LLC
-
+	fmt.Fprintln(os.Stderr, flags.Banner())
+	fmt.Fprintf(os.Stderr, `
 Performs the KERB-KEY-LIST-REQ attack to dump secrets from the remote machine
 without executing any agent there.
 

--- a/tools/lookupsid/main.go
+++ b/tools/lookupsid/main.go
@@ -63,7 +63,7 @@ func main() {
 		}
 	}
 
-	fmt.Println("gopacket v0.1.1-beta - Copyright 2026 Google LLC")
+	fmt.Println(flags.Banner())
 	fmt.Println()
 	fmt.Printf("[*] Brute forcing SIDs at %s\n", target.Host)
 

--- a/tools/mssqlclient/main.go
+++ b/tools/mssqlclient/main.go
@@ -42,7 +42,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	fmt.Println("gopacket v0.1.1-beta - Copyright 2026 Google LLC")
+	fmt.Println(flags.Banner())
 	fmt.Println()
 
 	// Parse target

--- a/tools/mssqlinstance/main.go
+++ b/tools/mssqlinstance/main.go
@@ -30,8 +30,8 @@ var (
 
 func main() {
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, `gopacket v0.1.1-beta - Copyright 2026 Google LLC
-
+		fmt.Fprintln(os.Stderr, flags.Banner())
+		fmt.Fprintf(os.Stderr, `
 SQL Server Browser Protocol discovery tool.
 
 Queries the SQL Server Browser service (UDP 1434) to enumerate SQL Server
@@ -68,7 +68,7 @@ Note: Requires the SQL Server Browser service to be running on the target.
 		os.Exit(1)
 	}
 
-	fmt.Println("gopacket v0.1.1-beta - Copyright 2026 Google LLC")
+	fmt.Println(flags.Banner())
 	fmt.Println()
 
 	target := flag.Arg(0)

--- a/tools/net/main.go
+++ b/tools/net/main.go
@@ -111,7 +111,7 @@ func main() {
 		}
 	}
 
-	fmt.Println("gopacket v0.1.1-beta - Copyright 2026 Google LLC")
+	fmt.Println(flags.Banner())
 	fmt.Println()
 
 	// Connect via SMB
@@ -196,7 +196,7 @@ func main() {
 }
 
 func printUsage() {
-	fmt.Fprintln(os.Stderr, "gopacket v0.1.1-beta - Copyright 2026 Google LLC")
+	fmt.Fprintln(os.Stderr, flags.Banner())
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Usage: net [auth-flags] target <command> [command-flags]")
 	fmt.Fprintln(os.Stderr)

--- a/tools/ntfs-read/main.go
+++ b/tools/ntfs-read/main.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/mandiant/gopacket/pkg/flags"
 	"github.com/mandiant/gopacket/pkg/ntfs"
 )
 
@@ -400,7 +401,7 @@ func cleanPath(path string) string {
 }
 
 func printUsage() {
-	fmt.Println("gopacket v0.1.1-beta - Copyright 2026 Google LLC")
+	fmt.Println(flags.Banner())
 	fmt.Println()
 	fmt.Println("NTFS explorer (read-only)")
 	fmt.Println()

--- a/tools/ping/main.go
+++ b/tools/ping/main.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/mandiant/gopacket/pkg/flags"
 	"golang.org/x/net/icmp"
 	"golang.org/x/net/ipv4"
 )
@@ -32,7 +33,7 @@ const (
 
 func main() {
 	if len(os.Args) < 3 {
-		fmt.Fprintf(os.Stderr, "gopacket v0.1.1-beta - Copyright 2026 Google LLC\n\n")
+		fmt.Fprintf(os.Stderr, "%s\n\n", flags.Banner())
 		fmt.Fprintf(os.Stderr, "Simple ICMP ping using raw sockets.\n\n")
 		fmt.Fprintf(os.Stderr, "Usage: %s <src ip> <dst ip>\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, "\nNote: Requires root/CAP_NET_RAW privileges.\n")

--- a/tools/ping6/main.go
+++ b/tools/ping6/main.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/mandiant/gopacket/pkg/flags"
 	"golang.org/x/net/icmp"
 	"golang.org/x/net/ipv6"
 )
@@ -30,7 +31,7 @@ const (
 )
 
 func main() {
-	fmt.Println("gopacket v0.1.1-beta - Copyright 2026 Google LLC")
+	fmt.Println(flags.Banner())
 	fmt.Println()
 
 	if len(os.Args) < 3 {

--- a/tools/rbcd/main.go
+++ b/tools/rbcd/main.go
@@ -30,8 +30,8 @@ import (
 )
 
 func printUsage() {
-	fmt.Fprintf(os.Stderr, `gopacket v0.1.1-beta - Copyright 2026 Google LLC
-
+	fmt.Fprintln(os.Stderr, flags.Banner())
+	fmt.Fprintf(os.Stderr, `
 usage: rbcd [-h] [-delegate-to DELEGATE_TO] [-delegate-from DELEGATE_FROM]
             [-action {read,write,remove,flush}] [-use-ldaps] [-debug] [-ts]
             [-hashes LMHASH:NTHASH] [-no-pass] [-k] [-aesKey hex key]

--- a/tools/reg/main.go
+++ b/tools/reg/main.go
@@ -107,7 +107,7 @@ func main() {
 		}
 	}
 
-	fmt.Println("gopacket v0.1.1-beta - Copyright 2026 Google LLC")
+	fmt.Println(flags.Banner())
 	fmt.Println()
 
 	// Connect via SMB
@@ -192,7 +192,7 @@ func main() {
 }
 
 func printUsage() {
-	fmt.Fprintln(os.Stderr, "gopacket v0.1.1-beta - Copyright 2026 Google LLC")
+	fmt.Fprintln(os.Stderr, flags.Banner())
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Usage: reg [auth-flags] target <command> [command-flags]")
 	fmt.Fprintln(os.Stderr)

--- a/tools/rpcdump/main.go
+++ b/tools/rpcdump/main.go
@@ -37,7 +37,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	fmt.Println("gopacket v0.1.1-beta - Copyright 2026 Google LLC")
+	fmt.Println(flags.Banner())
 	fmt.Println()
 
 	target, creds, err := session.ParseTargetString(opts.TargetStr)

--- a/tools/rpcmap/main.go
+++ b/tools/rpcmap/main.go
@@ -90,8 +90,8 @@ type ifaceResult struct {
 
 func main() {
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, `gopacket v0.1.1-beta - Copyright 2026 Google LLC
-
+		fmt.Fprintln(os.Stderr, flags.Banner())
+		fmt.Fprintf(os.Stderr, `
 Scans for listening MSRPC interfaces. Tries the MGMT interface first,
 falls back to UUID bruteforce if MGMT is not available.
 
@@ -121,7 +121,7 @@ Examples:
 		os.Exit(1)
 	}
 
-	fmt.Println("gopacket v0.1.1-beta - Copyright 2026 Google LLC")
+	fmt.Println(flags.Banner())
 	fmt.Println()
 
 	if *debug {

--- a/tools/samrdump/main.go
+++ b/tools/samrdump/main.go
@@ -55,7 +55,7 @@ func main() {
 		}
 	}
 
-	fmt.Println("gopacket v0.1.1-beta - Copyright 2026 Google LLC")
+	fmt.Println(flags.Banner())
 	fmt.Println()
 	fmt.Printf("[*] Retrieving endpoint list from %s\n", target.Host)
 

--- a/tools/services/main.go
+++ b/tools/services/main.go
@@ -100,7 +100,7 @@ func main() {
 		}
 	}
 
-	fmt.Println("gopacket v0.1.1-beta - Copyright 2026 Google LLC")
+	fmt.Println(flags.Banner())
 	fmt.Println()
 
 	// Connect via SMB
@@ -390,7 +390,7 @@ func errorControlName(t uint32) string {
 }
 
 func printUsage() {
-	fmt.Fprintln(os.Stderr, "gopacket v0.1.1-beta - Copyright 2026 Google LLC")
+	fmt.Fprintln(os.Stderr, flags.Banner())
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Usage: services [auth-flags] target <action> [action-flags]")
 	fmt.Fprintln(os.Stderr)

--- a/tools/smbserver/main.go
+++ b/tools/smbserver/main.go
@@ -366,7 +366,7 @@ func (s *Server) GetShares() []*Share {
 
 func main() {
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "gopacket v0.1.1-beta - Copyright 2026 Google LLC\n\n")
+		fmt.Fprintf(os.Stderr, "%s\n\n", flags.Banner())
 		fmt.Fprintf(os.Stderr, "usage: smbserver [-h] [-comment COMMENT] [-username USERNAME]\n")
 		fmt.Fprintf(os.Stderr, "                 [-password PASSWORD] [-hashes LMHASH:NTHASH] [-ts]\n")
 		fmt.Fprintf(os.Stderr, "                 [-debug] [-ip INTERFACE_ADDRESS] [-port PORT]\n")

--- a/tools/sniff/main.go
+++ b/tools/sniff/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcap"
+	"github.com/mandiant/gopacket/pkg/flags"
 )
 
 // Supported datalink types
@@ -43,8 +44,8 @@ var (
 
 func main() {
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, `gopacket v0.1.1-beta - Copyright 2026 Google LLC
-
+		fmt.Fprintln(os.Stderr, flags.Banner())
+		fmt.Fprintf(os.Stderr, `
 Simple packet sniffer using pcap.
 
 Usage: %s [options] [BPF filter]
@@ -65,7 +66,7 @@ Note: Requires root/CAP_NET_RAW privileges.
 
 	flag.Parse()
 
-	fmt.Println("gopacket v0.1.1-beta - Copyright 2026 Google LLC")
+	fmt.Println(flags.Banner())
 	fmt.Println()
 
 	// List interfaces mode

--- a/tools/sniffer/main.go
+++ b/tools/sniffer/main.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
+	"github.com/mandiant/gopacket/pkg/flags"
 )
 
 // Protocol name to number mapping
@@ -40,7 +41,7 @@ var protoMap = map[string]int{
 }
 
 func main() {
-	fmt.Println("gopacket v0.1.1-beta - Copyright 2026 Google LLC")
+	fmt.Println(flags.Banner())
 	fmt.Println()
 
 	// Default protocols if none specified

--- a/tools/split/main.go
+++ b/tools/split/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/gopacket/layers"
 	"github.com/google/gopacket/pcap"
 	"github.com/google/gopacket/pcapgo"
+	"github.com/mandiant/gopacket/pkg/flags"
 )
 
 // Supported datalink types
@@ -61,7 +62,7 @@ type ConnectionWriter struct {
 }
 
 func main() {
-	fmt.Println("gopacket v0.1.1-beta - Copyright 2026 Google LLC")
+	fmt.Println(flags.Banner())
 	fmt.Println()
 	fmt.Println("[!] This tool is deprecated and may be removed in future versions.")
 	fmt.Println()

--- a/tools/ticketer/main.go
+++ b/tools/ticketer/main.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/mandiant/gopacket/internal/build"
+	"github.com/mandiant/gopacket/pkg/flags"
 	"github.com/mandiant/gopacket/pkg/kerberos"
 )
 
@@ -446,7 +447,7 @@ func parseExtraSIDs() []string {
 }
 
 func usage() {
-	fmt.Fprintf(os.Stderr, "gopacket v0.1.1-beta - Copyright 2026 Google LLC\n\n")
+	fmt.Fprintf(os.Stderr, "%s\n\n", flags.Banner())
 	fmt.Fprintf(os.Stderr, "Creates Kerberos golden/silver/sapphire tickets based on user options\n\n")
 	fmt.Fprintf(os.Stderr, "Usage: ticketer [options] <target>\n\n")
 	fmt.Fprintf(os.Stderr, "Positional:\n")

--- a/tools/tstool/main.go
+++ b/tools/tstool/main.go
@@ -108,7 +108,7 @@ func main() {
 		}
 	}
 
-	fmt.Println("gopacket v0.1.1-beta - Copyright 2026 Google LLC")
+	fmt.Println(flags.Banner())
 	fmt.Println()
 
 	// Connect via SMB
@@ -809,7 +809,7 @@ func cmdMsg(smbClient *smb.Client, auth *authContext, sessionID int, title, mess
 }
 
 func printUsage() {
-	fmt.Fprintln(os.Stderr, "gopacket v0.1.1-beta - Copyright 2026 Google LLC")
+	fmt.Fprintln(os.Stderr, flags.Banner())
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Usage: tstool [auth-flags] target <action> [action-flags]")
 	fmt.Fprintln(os.Stderr)

--- a/tools/wmipersist/main.go
+++ b/tools/wmipersist/main.go
@@ -59,8 +59,8 @@ var (
 )
 
 func printUsage() {
-	fmt.Fprintf(os.Stderr, `gopacket v0.1.1-beta - Copyright 2026 Google LLC
-
+	fmt.Fprintln(os.Stderr, flags.Banner())
+	fmt.Fprintf(os.Stderr, `
 usage: wmipersist [-h] [-debug] [-ts] [-com-version MAJOR_VERSION:MINOR_VERSION]
                   [-hashes LMHASH:NTHASH] [-no-pass] [-k] [-aesKey hex key]
                   [-dc-ip ip address]


### PR DESCRIPTION
## Summary

26 tools hardcoded the literal `gopacket vX.Y.Z-beta - Copyright 2026 Google LLC` banner in print statements, totaling 34 occurrences across the tree. Every version bump meant updating the same string 34 times in 27 files (26 tools plus `pkg/flags/flags.go`).

Switches every tool to call `flags.Banner()`, which builds the banner from `flags.Version`. The `Version` const in `pkg/flags/flags.go` is now the single source of truth; future bumps are a one-line change.

## Mechanical split

Three common print patterns (`fmt.Println`, `fmt.Fprintln(os.Stderr, ...)`, `fmt.Fprintf(os.Stderr, "...\n\n")`) were swept with `sed`.

Six heredoc-style `flag.Usage` functions had the banner line on a backtick-quoted format string. Each was split into a separate `fmt.Fprintln(os.Stderr, flags.Banner())` followed by the existing `Fprintf` with the banner line trimmed off the format string. Output is byte-identical.

Nine tools needed a new `pkg/flags` import added: `describeTicket`, `getArch`, `ntfs-read`, `ping`, `ping6`, `sniff`, `sniffer`, `split`, `ticketer`.

`tools/describeTicket` already imports `github.com/jcmturner/gokrb5/v8/iana/flags` for Kerberos flag constants (used in 14 places), so `pkg/flags` is aliased as `gopflags` there to avoid the name collision.

## Test plan

- [x] `go build ./...` clean (default, cgo=1 Linux)
- [x] `CGO_ENABLED=0 go build ./...` clean
- [x] `GOOS=windows CGO_ENABLED=0 go build ./...` clean
- [x] `go vet ./...` clean across all three configurations
- [x] `go test ./pkg/transport/` passes, 13/13
- [x] Spot-checked `-h` output on samrdump (Println pattern), rpcmap (heredoc), mssqlinstance (heredoc with Fprintf), ping (Fprintf with `\n\n`), and describeTicket (aliased import). Every tool renders the banner identically to before.