### PR TITLE
security: reject ACE with AceSize below minimum header size

### DIFF
--- a/pkg/security/ace.go
+++ b/pkg/security/ace.go
@@ -48,6 +48,9 @@ func ParseACE(data []byte) (*ACE, int, error) {
 		Flags: data[1],
 	}
 	aceSize := int(binary.LittleEndian.Uint16(data[2:4]))
+	if aceSize < 8 {
+		return nil, 0, fmt.Errorf("ACE size %d is below minimum header size of 8", aceSize)
+	}
 	if len(data) < aceSize {
 		return nil, 0, fmt.Errorf("ACE size %d exceeds available data %d", aceSize, len(data))
 	}


### PR DESCRIPTION
When AceSize is less than 8, the fixed 4-byte header plus 4-byte Mask are not contained in the ACE. The existing  check passes (len(data) may be >= 8) but later slices like  and  panic with 'slice bounds out of range'.

This adds a simple bounds check: if , return an error immediately after reading the AceSize field.

Fixes #23