### PR TITLE
wmiexec: fix early return on long-running commands

### DIFF
--- a/tools/wmiexec/main.go
+++ b/tools/wmiexec/main.go
@@ -518,18 +518,18 @@ func (e *WMIExec) retrieveOutput(filename string) (string, error) {
 		content, err := smbClient.Cat(filename)
 		if err == nil {
 			// Delete the output file
-			smbClient.Rm(filename)
+			if err := smbClient.Rm(filename); err != nil {
+				// If sharing violation, command is still running
+				if strings.Contains(err.Error(), "share access flags are incompatible") {
+					e.log.Debug().Msg("Output file in use, waiting...")
+					continue
+				}
+			}
 			return content, nil
 		}
 
-		// If sharing violation, command is still running
-		if strings.Contains(err.Error(), "STATUS_SHARING_VIOLATION") {
-			e.log.Debug().Msg("Output file in use, waiting...")
-			continue
-		}
-
 		// If file not found, keep waiting
-		if strings.Contains(err.Error(), "STATUS_OBJECT_NAME_NOT_FOUND") {
+		if strings.Contains(err.Error(), "file does not exist") {
 			continue
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes #22 — `gopacket-wmiexec` returned early on long-running commands
(`systeminfo`, `ping`, etc.), producing empty output and leaving the
temporary file behind in `ADMIN$`.

The retrieval loop in `retrieveOutput` assumed `smbClient.Cat` would
return `STATUS_SHARING_VIOLATION` while the remote process still held the
output file open. In practice `Cat` succeeds (the SMB read share mode is
compatible) — it's `Rm` that fails on the lock. The old code therefore
took the `Cat` success path on the first poll and returned a partial /
empty buffer immediately, matching the symptoms in the issue.

## Changes

- Move the "still running" detection from `Cat` to `Rm`: if `Rm` returns
  a sharing-violation error after a successful `Cat`, keep polling
  instead of returning.
- Update error-string matching to what the SMB layer actually surfaces:
  `"share access flags are incompatible"` (was `STATUS_SHARING_VIOLATION`)
  and `"file does not exist"` (was `STATUS_OBJECT_NAME_NOT_FOUND`).

Behavior now matches Impacket's `wmiexec.py`: the tool waits for the
remote process to release the output file before reading and unlinking
it.

## Test plan

- [ ] `go build ./...`
- [ ] `go vet ./...`
- [ ] Live target: `gopacket-wmiexec ... systeminfo` returns full output and removes the temp file
- [ ] Live target: `gopacket-wmiexec ... whoami` (fast command) still works
