### PR TITLE
exec-tools: fix output polling for long-running commands

### DIFF
--- a/pkg/smb/errors.go
+++ b/pkg/smb/errors.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package smb
+
+import (
+	"errors"
+	"os"
+
+	"github.com/mandiant/gopacket/pkg/third_party/smb2"
+)
+
+// NTSTATUS values from [MS-ERREF]. The smb2 erref package is internal, so we
+// match the codes on *smb2.ResponseError.Code directly.
+const (
+	ntStatusObjectNameNotFound uint32 = 0xC0000034
+	ntStatusObjectPathNotFound uint32 = 0xC000003A
+	ntStatusSharingViolation   uint32 = 0xC0000043
+)
+
+// IsSharingViolation reports whether err wraps STATUS_SHARING_VIOLATION.
+// The smb2 client wraps server responses in *os.PathError → *smb2.ResponseError,
+// so substring matching on err.Error() is unreliable.
+func IsSharingViolation(err error) bool {
+	return ntStatusIs(err, ntStatusSharingViolation)
+}
+
+// IsNotFound reports whether err means the SMB target file or path does not
+// exist. The smb2 layer translates STATUS_OBJECT_NAME_NOT_FOUND and
+// STATUS_OBJECT_PATH_NOT_FOUND to os.ErrNotExist in conn.go before wrapping,
+// so most call sites see the sentinel rather than an *smb2.ResponseError.
+// We accept both forms.
+func IsNotFound(err error) bool {
+	if errors.Is(err, os.ErrNotExist) {
+		return true
+	}
+	return ntStatusIs(err, ntStatusObjectNameNotFound) ||
+		ntStatusIs(err, ntStatusObjectPathNotFound)
+}
+
+func ntStatusIs(err error, want uint32) bool {
+	if err == nil {
+		return false
+	}
+	var pe *os.PathError
+	if errors.As(err, &pe) {
+		err = pe.Err
+	}
+	var re *smb2.ResponseError
+	if errors.As(err, &re) {
+		return re.Code == want
+	}
+	return false
+}

--- a/pkg/smb/errors_test.go
+++ b/pkg/smb/errors_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+
+package smb
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/mandiant/gopacket/pkg/third_party/smb2"
+)
+
+func TestIsSharingViolation(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"plain error", errors.New("boom"), false},
+		{"raw response error", &smb2.ResponseError{Code: ntStatusSharingViolation}, true},
+		{"wrapped in PathError", &os.PathError{Op: "remove", Path: "x", Err: &smb2.ResponseError{Code: ntStatusSharingViolation}}, true},
+		{"different NTSTATUS", &os.PathError{Op: "remove", Path: "x", Err: &smb2.ResponseError{Code: ntStatusObjectNameNotFound}}, false},
+		{"fmt-wrapped", fmt.Errorf("retrieval: %w", &smb2.ResponseError{Code: ntStatusSharingViolation}), true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsSharingViolation(tc.err); got != tc.want {
+				t.Errorf("IsSharingViolation(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"name not found", &os.PathError{Op: "open", Path: "x", Err: &smb2.ResponseError{Code: ntStatusObjectNameNotFound}}, true},
+		{"path not found", &os.PathError{Op: "open", Path: "x", Err: &smb2.ResponseError{Code: ntStatusObjectPathNotFound}}, true},
+		{"os.ErrNotExist sentinel (smb2 translates name_not_found here)", &os.PathError{Op: "open", Path: "__output", Err: os.ErrNotExist}, true},
+		{"bare os.ErrNotExist", os.ErrNotExist, true},
+		{"sharing violation", &os.PathError{Op: "remove", Path: "x", Err: &smb2.ResponseError{Code: ntStatusSharingViolation}}, false},
+		{"unrelated error", errors.New("no such file"), false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsNotFound(tc.err); got != tc.want {
+				t.Errorf("IsNotFound(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/tools/atexec/main.go
+++ b/tools/atexec/main.go
@@ -322,18 +322,16 @@ func (e *AtExec) getOutput(tmpFileName string) string {
 
 		content, err := e.smbClient.Cat(outputPath)
 		if err == nil {
-			// Delete the output file
-			e.smbClient.Rm(outputPath)
+			// Cat succeeds even while the remote process is still writing;
+			// Rm is what fails with a sharing violation in that case.
+			if rmErr := e.smbClient.Rm(outputPath); rmErr != nil && smb.IsSharingViolation(rmErr) {
+				continue
+			}
 			return content
 		}
 
-		// If sharing violation, command is still running
-		if strings.Contains(err.Error(), "STATUS_SHARING_VIOLATION") {
-			continue
-		}
-
-		// If file not found, keep waiting
-		if strings.Contains(err.Error(), "STATUS_OBJECT_NAME_NOT_FOUND") {
+		// File not yet created — keep waiting.
+		if smb.IsNotFound(err) {
 			continue
 		}
 	}

--- a/tools/dcomexec/main.go
+++ b/tools/dcomexec/main.go
@@ -977,18 +977,19 @@ func (e *DCOMExec) getOutput() string {
 
 		content, err := e.smbClient.Cat(outputPath)
 		if err == nil {
-			e.smbClient.Rm(outputPath)
+			// Cat succeeds even while the remote process is still writing;
+			// Rm is what fails with a sharing violation in that case.
+			if rmErr := e.smbClient.Rm(outputPath); rmErr != nil && smb.IsSharingViolation(rmErr) {
+				waited = 0
+				continue
+			}
 			return e.decodeOutput(content)
 		}
 
 		errStr := err.Error()
 
-		if strings.Contains(errStr, "STATUS_SHARING_VIOLATION") {
-			waited = 0
-			continue
-		}
-
-		// Connection broken — reconnect and retry (matches Impacket)
+		// Connection broken — reconnect and retry (matches Impacket).
+		// These come from net, not smb2, so substring matching is the right tool.
 		if strings.Contains(errStr, "broken") || strings.Contains(errStr, "connection reset") || strings.Contains(errStr, "use of closed") {
 			e.log.Debug().Msg("Connection broken, trying to recreate it")
 			e.smbClient.Close()
@@ -1000,10 +1001,8 @@ func (e *DCOMExec) getOutput() string {
 			return e.getOutput()
 		}
 
-		// File not found yet — keep waiting up to timeout
-		if strings.Contains(errStr, "STATUS_OBJECT_NAME_NOT_FOUND") ||
-			strings.Contains(errStr, "does not exist") ||
-			strings.Contains(errStr, "not found") {
+		// File not found yet — keep waiting up to timeout.
+		if smb.IsNotFound(err) {
 			if waited >= maxWait {
 				return ""
 			}

--- a/tools/smbexec/main.go
+++ b/tools/smbexec/main.go
@@ -379,20 +379,18 @@ func (e *SMBExec) getOutputShare() (string, error) {
 
 		c, err := e.smbClient.Cat(outputFilename)
 		if err == nil {
+			// Cat succeeds even while the remote process is still writing;
+			// Rm is what fails with a sharing violation in that case.
+			if rmErr := e.smbClient.Rm(outputFilename); rmErr != nil && smb.IsSharingViolation(rmErr) {
+				e.log.Debug().Msg("Output file in use, waiting...")
+				continue
+			}
 			content = c
-			// Delete the output file
-			e.smbClient.Rm(outputFilename)
 			break
 		}
 
-		// If sharing violation, command is still running
-		if strings.Contains(err.Error(), "STATUS_SHARING_VIOLATION") {
-			e.log.Debug().Msg("Output file in use, waiting...")
-			continue
-		}
-
-		// If file not found, keep waiting a bit
-		if strings.Contains(err.Error(), "STATUS_OBJECT_NAME_NOT_FOUND") {
+		// File not yet created — keep waiting a bit.
+		if smb.IsNotFound(err) {
 			continue
 		}
 

--- a/tools/wmiexec/main.go
+++ b/tools/wmiexec/main.go
@@ -517,19 +517,19 @@ func (e *WMIExec) retrieveOutput(filename string) (string, error) {
 
 		content, err := smbClient.Cat(filename)
 		if err == nil {
-			// Delete the output file
-			smbClient.Rm(filename)
+			// Cat succeeds even while the remote process is still writing
+			// (read share-mode is compatible). Rm needs DELETE access, which
+			// is what actually conflicts — so a sharing violation here means
+			// the command is still running and the content is partial.
+			if rmErr := smbClient.Rm(filename); rmErr != nil && smb.IsSharingViolation(rmErr) {
+				e.log.Debug().Msg("Output file in use, waiting...")
+				continue
+			}
 			return content, nil
 		}
 
-		// If sharing violation, command is still running
-		if strings.Contains(err.Error(), "STATUS_SHARING_VIOLATION") {
-			e.log.Debug().Msg("Output file in use, waiting...")
-			continue
-		}
-
-		// If file not found, keep waiting
-		if strings.Contains(err.Error(), "STATUS_OBJECT_NAME_NOT_FOUND") {
+		// File not yet created — keep waiting.
+		if smb.IsNotFound(err) {
 			continue
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes the output-retrieval bug reported in #22 for **wmiexec**, and applies the same fix to **atexec**, **smbexec**, and **dcomexec** which all carried the identical broken pattern. Supersedes #29 (which only addressed wmiexec).

### Two compounding bugs

1. **Sharing-violation check was on the wrong call.** The polling loop watched `smbClient.Cat` for `STATUS_SHARING_VIOLATION` to detect "command still running." But `Cat` opens with `FILE_SHARE_READ`-compatible access and succeeds against the writer on the first poll, returning the file as it currently exists (typically empty). The conflict actually lives on `Rm` — deleting needs `DELETE` access, which conflicts with the writer's share mode. Moved the check to `Rm`. Matches Impacket's `wmiexec.py`.

2. **String match was dead.** `strings.Contains(err.Error(), "STATUS_SHARING_VIOLATION")` could never fire — the underlying smb2 library's `NtStatus.Error()` returns only the human description (`"A file cannot be opened because the share access flags are incompatible."`). Same issue for `STATUS_OBJECT_NAME_NOT_FOUND` (further muddled by `smb2/conn.go` translating that NTSTATUS to `os.ErrNotExist` before wrapping).

### Fix

New typed helpers in `pkg/smb/errors.go` (`IsSharingViolation`, `IsNotFound`) that unwrap through `*os.PathError` and match on `*smb2.ResponseError.Code` plus the `os.ErrNotExist` sentinel. NTSTATUS values are hardcoded because `smb2/internal/erref` can't be imported from outside the smb2 tree. All four exec tools updated to use the helpers and the Cat→Rm pattern.

The dcomexec `broken / connection reset / use of closed` branch stays string-matched — those errors come from `net`, not smb2.

Thanks to @aimogging for the diagnosis and PoC in #22/#29 — this PR closes both with a holistic fix and replaces the substring matching with typed-error helpers so future smb2 library changes don't silently break the check again.

Closes #22
Closes #29

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./pkg/smb/...` — helper unit tests pass (covers raw, PathError-wrapped, fmt-wrapped, and `os.ErrNotExist` forms)
- [x] Lab regression against GOAD winterfell: `wmiexec whoami / systeminfo / ping -n 4 1.1.1.1` all return full output, exit 0, no ADMIN$ residue
- [x] Same wmiexec runs over `-proxy socks5h://...` (the setup the issue reporter used) — full output retrieved