### PR TITLE
drsuapi: drop writeDSNAME structLen +2 cargo-cult

### DIFF
--- a/pkg/dcerpc/drsuapi/getncchanges.go
+++ b/pkg/dcerpc/drsuapi/getncchanges.go
@@ -246,14 +246,15 @@ func writeDSNAME(buf *bytes.Buffer, nameOrGUID string) {
 
 	// Calculate structLen: the size of the entire DSNAME structure
 	// structLen(4) + SidLen(4) + Guid(16) + Sid(28) + NameLen(4) + StringName((nameLen+1)*2)
+	// MS-DRSR 4.1.4.1.1 specifies structLen as the exact byte size, rounded
+	// to a 4-byte boundary. Impacket carries a "+2" on top of the round-up
+	// that no part of the spec or wire trace justifies; AD is forgiving but
+	// a stricter implementation would reject. Keep just the alignment round.
 	stringNameBytes := charCount * 2
 	structLen := uint32(4 + 4 + 16 + 28 + 4 + stringNameBytes)
-	// Align to 4-byte boundary for the structure size
 	if structLen%4 != 0 {
 		structLen += 4 - (structLen % 4)
 	}
-	// Per Impacket, add 2 more bytes (possibly for additional alignment)
-	structLen += 2
 
 	// Track start for final alignment
 	startOffset := buf.Len()


### PR DESCRIPTION
## Summary

Closes the final item from #32. MS-DRSR 4.1.4.1.1 specifies `structLen` as the exact byte size of the DSNAME structure, rounded up to a 4-byte boundary. The previous code applied the round-up and then added 2 more bytes "per Impacket" — neither the spec nor the wire trace justifies the extra 2 bytes. AD is forgiving in practice but a stricter implementation could reject. With the `+2` in place the advertised `structLen` was systematically congruent to 2 mod 4 (i.e. off the alignment) and 2 bytes larger than the actual serialized payload. The trailing `written % 4` round at the end of `writeDSNAME` already handles wire-side NDR alignment, so dropping the `+2` doesn't leave a gap.

## Verification

Item 3 was held out of #33 because it's request-side and there's no parser-side regression detection. Verified end-to-end against the GOAD lab:

- **Forest root** (`sevenkingdoms.local`, kingslanding @ 10.10.10.10) — `secretsdump --just-dc-ntlm` exercises `DsBind` → `DsDomainControllerInfo` → `DsCrackNames` (via `GetDomainDN`) → `DsGetNCChanges`. All four returned success; full account dump captured.
- **Child domain** (`north.sevenkingdoms.local`, winterfell @ 10.10.10.11) — same four-RPC sequence, full dump captured.
- Output is **byte-for-byte identical** to the dumps captured with the `+2` in place (the same dumps from #33's lab pass).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./pkg/dcerpc/drsuapi/...`
- [x] `go test ./pkg/dcerpc/drsuapi/...`
- [x] `secretsdump --just-dc-ntlm` against forest root (sevenkingdoms.local)
- [x] `secretsdump --just-dc-ntlm` against child domain (north.sevenkingdoms.local)
- [x] Diff of pre-fix vs post-fix dumps shows zero differences

Closes #32.