### PR TITLE
Allow Multiple SMB Dialects

### DIFF
--- a/pkg/smb/client.go
+++ b/pkg/smb/client.go
@@ -133,8 +133,6 @@ func (c *Client) Connect() error {
 		Initiator: initiator,
 
 		Negotiator: smb2.Negotiator{
-
-			SpecifiedDialect:      0x0210,
 			RequireMessageSigning: true,
 		},
 	}


### PR DESCRIPTION
Sticking to SMB 2.1.0 causes SMB Negotiate to fail on old windows server versions, the smb2 package allows for more if not specified 

```go
type Negotiator struct {
        // ....
	SpecifiedDialect      uint16   // if it's zero, clientDialects is used. (See feature.go for more details)
}
```